### PR TITLE
Increase node server's stack size

### DIFF
--- a/Reality Editor iOS/WebView/WebServerManager.m
+++ b/Reality Editor iOS/WebView/WebServerManager.m
@@ -37,8 +37,8 @@
                         selector:@selector(startNode)
                         object:nil
                         ];
-        // Set 2MB of stack space for the Node.js thread.
-        [nodejsThread setStackSize:2*1024*1024];
+        // Set stack space for the Node.js thread, measured in bytes
+        [nodejsThread setStackSize:8*1024*1024];
         [nodejsThread start];
         
     }


### PR DESCRIPTION
There's no reason to try to limit it since the server's in charge of so
many things that it needs all the memory it can get.