### PR TITLE
updates the allowDisplayingKeyboardWithoutUserAction swizzle for iOS 13

### DIFF
--- a/Vuforia Spatial Toolbox/WebView/REWebView.mm
+++ b/Vuforia Spatial Toolbox/WebView/REWebView.mm
@@ -64,13 +64,31 @@
 }
 
 // Allows javascript to programmatically open the keyboard without explicitly tapping on a native text field element (disabled by default)
-// Non-intuitive solution, taken from https://stackoverflow.com/a/48623286/1190267
+// Non-intuitive solution, taken from https://stackoverflow.com/a/48623286/1190267 (updated for iOS 12 and 13 as of 3-4-2020)
 + (void)allowDisplayingKeyboardWithoutUserAction {
     Class thisClass = NSClassFromString(@"WKContentView");
     NSOperatingSystemVersion iOS_11_3_0 = (NSOperatingSystemVersion){11, 3, 0};
-
-    // different solution for iOS 11 compared to earlier versions
-    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion: iOS_11_3_0]) {
+    NSOperatingSystemVersion iOS_12_2_0 = (NSOperatingSystemVersion){12, 2, 0};
+    NSOperatingSystemVersion iOS_13_0_0 = (NSOperatingSystemVersion){13, 0, 0};
+    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion: iOS_13_0_0]) {
+        SEL selector = sel_getUid("_elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:");
+        Method method = class_getInstanceMethod(thisClass, selector);
+        IMP original = method_getImplementation(method);
+        IMP override = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, BOOL arg3, id arg4) {
+        ((void (*)(id, SEL, void*, BOOL, BOOL, BOOL, id))original)(me, selector, arg0, TRUE, arg2, arg3, arg4);
+        });
+        method_setImplementation(method, override);
+    }
+   else if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion: iOS_12_2_0]) {
+        SEL selector = sel_getUid("_elementDidFocus:userIsInteracting:blurPreviousNode:changingActivityState:userObject:");
+        Method method = class_getInstanceMethod(thisClass, selector);
+        IMP original = method_getImplementation(method);
+        IMP override = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, BOOL arg3, id arg4) {
+        ((void (*)(id, SEL, void*, BOOL, BOOL, BOOL, id))original)(me, selector, arg0, TRUE, arg2, arg3, arg4);
+        });
+        method_setImplementation(method, override);
+    }
+    else if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion: iOS_11_3_0]) {
         SEL selector = sel_getUid("_startAssistingNode:userIsInteracting:blurPreviousNode:changingActivityState:userObject:");
         Method method = class_getInstanceMethod(thisClass, selector);
         IMP original = method_getImplementation(method);


### PR DESCRIPTION
so that webkit doesnt block us from programatically opening keyboards