### PR TITLE
Update afnetworking

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -8,6 +8,6 @@ target 'Vuforia Spatial Toolbox' do
   # Pods for Vuforia Spatial Toolbox
   pod 'CocoaAsyncSocket'
   pod 'GCDWebServer', '~> 3.0'
-  pod 'AFNetworking', '~> 3.0', :subspecs => ['Reachability', 'Serialization', 'Security', 'NSURLSession']
+  pod 'AFNetworking', '~> 3.0', :subspecs => ['NSURLSession']
 
 end

--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,6 @@ target 'Vuforia Spatial Toolbox' do
   # Pods for Vuforia Spatial Toolbox
   pod 'CocoaAsyncSocket'
   pod 'GCDWebServer', '~> 3.0'
-  pod 'AFNetworking', '~> 3.0'
-
+  pod 'AFNetworking', '~> 3.0', :subspecs => ['Reachability', 'Serialization', 'Security', 'NSURLSession']
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,4 @@
 PODS:
-  - AFNetworking (3.2.1):
-    - AFNetworking/NSURLSession (= 3.2.1)
-    - AFNetworking/Reachability (= 3.2.1)
-    - AFNetworking/Security (= 3.2.1)
-    - AFNetworking/Serialization (= 3.2.1)
-    - AFNetworking/UIKit (= 3.2.1)
   - AFNetworking/NSURLSession (3.2.1):
     - AFNetworking/Reachability
     - AFNetworking/Security
@@ -12,15 +6,16 @@ PODS:
   - AFNetworking/Reachability (3.2.1)
   - AFNetworking/Security (3.2.1)
   - AFNetworking/Serialization (3.2.1)
-  - AFNetworking/UIKit (3.2.1):
-    - AFNetworking/NSURLSession
   - CocoaAsyncSocket (7.6.3)
   - GCDWebServer (3.4.2):
     - GCDWebServer/Core (= 3.4.2)
   - GCDWebServer/Core (3.4.2)
 
 DEPENDENCIES:
-  - AFNetworking (~> 3.0)
+  - AFNetworking/NSURLSession (~> 3.0)
+  - AFNetworking/Reachability (~> 3.0)
+  - AFNetworking/Security (~> 3.0)
+  - AFNetworking/Serialization (~> 3.0)
   - CocoaAsyncSocket
   - GCDWebServer (~> 3.0)
 
@@ -35,6 +30,6 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: eafaa68a7e0ec99ead0a7b35015e0bf25d2c8987
   GCDWebServer: 8d67ee9f634b4bb91eb4b8aee440318a5fc6debd
 
-PODFILE CHECKSUM: 3cf90547c689f2c4cc188fe344a78a1b272e5fa7
+PODFILE CHECKSUM: b417afaace15216662973be017c816fbb9be46b2
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -13,9 +13,6 @@ PODS:
 
 DEPENDENCIES:
   - AFNetworking/NSURLSession (~> 3.0)
-  - AFNetworking/Reachability (~> 3.0)
-  - AFNetworking/Security (~> 3.0)
-  - AFNetworking/Serialization (~> 3.0)
   - CocoaAsyncSocket
   - GCDWebServer (~> 3.0)
 
@@ -30,6 +27,6 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: eafaa68a7e0ec99ead0a7b35015e0bf25d2c8987
   GCDWebServer: 8d67ee9f634b4bb91eb4b8aee440318a5fc6debd
 
-PODFILE CHECKSUM: b417afaace15216662973be017c816fbb9be46b2
+PODFILE CHECKSUM: 0f581365c9db2bc7e21a33d4d738b7a4379fed60
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Followed advice from https://github.com/AFNetworking/AFNetworking/issues/4428#issuecomment-531703705 to only install the part of AFNetworking we use and exclude the references to UIWebView, which is deprecated and not allowed on App Store anymore