### PR TITLE
fix the import line to only included needed AFNetworking library

### DIFF
--- a/Vuforia Spatial Toolbox/FileManager.m
+++ b/Vuforia Spatial Toolbox/FileManager.m
@@ -11,7 +11,7 @@
 //
 
 #import "FileManager.h"
-#import "AFNetworking.h"
+#import <AFNetworking/AFHTTPSessionManager.h>
 
 @implementation FileManager
 


### PR DESCRIPTION
hot fix for the master branch, updating the Podfile meant the AFNetworking.h file disappeared so we need to import the specific file instead of the entire library (better this way, anyways).