### PR TITLE
Toolbox UI debugger project

### DIFF
--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger.xcodeproj/project.pbxproj
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger.xcodeproj/project.pbxproj
@@ -1,0 +1,366 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		43827DC02437CCB500994A7A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 43827DBF2437CCB500994A7A /* AppDelegate.m */; };
+		43827DC32437CCB500994A7A /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 43827DC22437CCB500994A7A /* SceneDelegate.m */; };
+		43827DC62437CCB500994A7A /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 43827DC52437CCB500994A7A /* ViewController.m */; };
+		43827DC92437CCB500994A7A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 43827DC72437CCB500994A7A /* Main.storyboard */; };
+		43827DCB2437CCB500994A7A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 43827DCA2437CCB500994A7A /* Assets.xcassets */; };
+		43827DCE2437CCB500994A7A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 43827DCC2437CCB500994A7A /* LaunchScreen.storyboard */; };
+		43827DD12437CCB500994A7A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 43827DD02437CCB500994A7A /* main.m */; };
+		43827DD92437CCD600994A7A /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43827DD82437CCD600994A7A /* WebKit.framework */; };
+		43827DDB2437CCDF00994A7A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43827DDA2437CCDF00994A7A /* UIKit.framework */; };
+		43827DDD2437CEDD00994A7A /* userinterface in Resources */ = {isa = PBXBuildFile; fileRef = 43827DDC2437CEDD00994A7A /* userinterface */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		43827DBB2437CCB500994A7A /* Toolbox-UI-Debugger.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Toolbox-UI-Debugger.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		43827DBE2437CCB500994A7A /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		43827DBF2437CCB500994A7A /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		43827DC12437CCB500994A7A /* SceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SceneDelegate.h; sourceTree = "<group>"; };
+		43827DC22437CCB500994A7A /* SceneDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SceneDelegate.m; sourceTree = "<group>"; };
+		43827DC42437CCB500994A7A /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		43827DC52437CCB500994A7A /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		43827DC82437CCB500994A7A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		43827DCA2437CCB500994A7A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		43827DCD2437CCB500994A7A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		43827DCF2437CCB500994A7A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		43827DD02437CCB500994A7A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		43827DD82437CCD600994A7A /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
+		43827DDA2437CCDF00994A7A /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		43827DDC2437CEDD00994A7A /* userinterface */ = {isa = PBXFileReference; lastKnownFileType = folder; name = userinterface; path = ../../bin/data/userinterface; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		43827DB82437CCB500994A7A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				43827DD92437CCD600994A7A /* WebKit.framework in Frameworks */,
+				43827DDB2437CCDF00994A7A /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		43827DB22437CCB500994A7A = {
+			isa = PBXGroup;
+			children = (
+				43827DBD2437CCB500994A7A /* Toolbox-UI-Debugger */,
+				43827DBC2437CCB500994A7A /* Products */,
+				43827DD72437CCD600994A7A /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		43827DBC2437CCB500994A7A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				43827DBB2437CCB500994A7A /* Toolbox-UI-Debugger.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		43827DBD2437CCB500994A7A /* Toolbox-UI-Debugger */ = {
+			isa = PBXGroup;
+			children = (
+				43827DDC2437CEDD00994A7A /* userinterface */,
+				43827DBE2437CCB500994A7A /* AppDelegate.h */,
+				43827DBF2437CCB500994A7A /* AppDelegate.m */,
+				43827DC12437CCB500994A7A /* SceneDelegate.h */,
+				43827DC22437CCB500994A7A /* SceneDelegate.m */,
+				43827DC42437CCB500994A7A /* ViewController.h */,
+				43827DC52437CCB500994A7A /* ViewController.m */,
+				43827DC72437CCB500994A7A /* Main.storyboard */,
+				43827DCA2437CCB500994A7A /* Assets.xcassets */,
+				43827DCC2437CCB500994A7A /* LaunchScreen.storyboard */,
+				43827DCF2437CCB500994A7A /* Info.plist */,
+				43827DD02437CCB500994A7A /* main.m */,
+			);
+			path = "Toolbox-UI-Debugger";
+			sourceTree = "<group>";
+		};
+		43827DD72437CCD600994A7A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				43827DDA2437CCDF00994A7A /* UIKit.framework */,
+				43827DD82437CCD600994A7A /* WebKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		43827DBA2437CCB500994A7A /* Toolbox-UI-Debugger */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 43827DD42437CCB500994A7A /* Build configuration list for PBXNativeTarget "Toolbox-UI-Debugger" */;
+			buildPhases = (
+				43827DB72437CCB500994A7A /* Sources */,
+				43827DB82437CCB500994A7A /* Frameworks */,
+				43827DB92437CCB500994A7A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Toolbox-UI-Debugger";
+			productName = "Toolbox-UI-Debugger";
+			productReference = 43827DBB2437CCB500994A7A /* Toolbox-UI-Debugger.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		43827DB32437CCB500994A7A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				ORGANIZATIONNAME = "Reality Lab";
+				TargetAttributes = {
+					43827DBA2437CCB500994A7A = {
+						CreatedOnToolsVersion = 11.3;
+					};
+				};
+			};
+			buildConfigurationList = 43827DB62437CCB500994A7A /* Build configuration list for PBXProject "Toolbox-UI-Debugger" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 43827DB22437CCB500994A7A;
+			productRefGroup = 43827DBC2437CCB500994A7A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				43827DBA2437CCB500994A7A /* Toolbox-UI-Debugger */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		43827DB92437CCB500994A7A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				43827DCE2437CCB500994A7A /* LaunchScreen.storyboard in Resources */,
+				43827DDD2437CEDD00994A7A /* userinterface in Resources */,
+				43827DCB2437CCB500994A7A /* Assets.xcassets in Resources */,
+				43827DC92437CCB500994A7A /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		43827DB72437CCB500994A7A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				43827DC62437CCB500994A7A /* ViewController.m in Sources */,
+				43827DC02437CCB500994A7A /* AppDelegate.m in Sources */,
+				43827DD12437CCB500994A7A /* main.m in Sources */,
+				43827DC32437CCB500994A7A /* SceneDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		43827DC72437CCB500994A7A /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				43827DC82437CCB500994A7A /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		43827DCC2437CCB500994A7A /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				43827DCD2437CCB500994A7A /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		43827DD22437CCB500994A7A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		43827DD32437CCB500994A7A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		43827DD52437CCB500994A7A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = DCHD5JFKNC;
+				INFOPLIST_FILE = "Toolbox-UI-Debugger/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ptc.Toolbox-UI-Debugger";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		43827DD62437CCB500994A7A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = DCHD5JFKNC;
+				INFOPLIST_FILE = "Toolbox-UI-Debugger/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ptc.Toolbox-UI-Debugger";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		43827DB62437CCB500994A7A /* Build configuration list for PBXProject "Toolbox-UI-Debugger" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				43827DD22437CCB500994A7A /* Debug */,
+				43827DD32437CCB500994A7A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		43827DD42437CCB500994A7A /* Build configuration list for PBXNativeTarget "Toolbox-UI-Debugger" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				43827DD52437CCB500994A7A /* Debug */,
+				43827DD62437CCB500994A7A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 43827DB32437CCB500994A7A /* Project object */;
+}

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Toolbox-UI-Debugger.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/AppDelegate.h
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/AppDelegate.h
@@ -1,0 +1,15 @@
+//
+//  AppDelegate.h
+//  Toolbox-UI-Debugger
+//
+//  Created by Benjamin Reynolds on 4/3/20.
+//  Copyright © 2020 Reality Lab. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+
+@end
+

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/AppDelegate.m
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/AppDelegate.m
@@ -1,0 +1,41 @@
+//
+//  AppDelegate.m
+//  Toolbox-UI-Debugger
+//
+//  Created by Benjamin Reynolds on 4/3/20.
+//  Copyright © 2020 Reality Lab. All rights reserved.
+//
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after application launch.
+    return YES;
+}
+
+
+#pragma mark - UISceneSession lifecycle
+
+
+- (UISceneConfiguration *)application:(UIApplication *)application configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession options:(UISceneConnectionOptions *)options {
+    // Called when a new scene session is being created.
+    // Use this method to select a configuration to create the new scene with.
+    return [[UISceneConfiguration alloc] initWithName:@"Default Configuration" sessionRole:connectingSceneSession.role];
+}
+
+
+- (void)application:(UIApplication *)application didDiscardSceneSessions:(NSSet<UISceneSession *> *)sceneSessions {
+    // Called when the user discards a scene session.
+    // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+    // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+}
+
+
+@end

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/Assets.xcassets/Contents.json
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/Base.lproj/LaunchScreen.storyboard
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/Base.lproj/Main.storyboard
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/Base.lproj/Main.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="139" y="138"/>
+        </scene>
+    </scenes>
+</document>

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/Info.plist
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/Info.plist
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/SceneDelegate.h
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/SceneDelegate.h
@@ -1,0 +1,16 @@
+//
+//  SceneDelegate.h
+//  Toolbox-UI-Debugger
+//
+//  Created by Benjamin Reynolds on 4/3/20.
+//  Copyright © 2020 Reality Lab. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface SceneDelegate : UIResponder <UIWindowSceneDelegate>
+
+@property (strong, nonatomic) UIWindow * window;
+
+@end
+

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/SceneDelegate.m
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/SceneDelegate.m
@@ -1,0 +1,50 @@
+#import "SceneDelegate.h"
+
+@interface SceneDelegate ()
+
+@end
+
+@implementation SceneDelegate
+
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions {
+    // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+    // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+    // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+}
+
+
+- (void)sceneDidDisconnect:(UIScene *)scene {
+    // Called as the scene is being released by the system.
+    // This occurs shortly after the scene enters the background, or when its session is discarded.
+    // Release any resources associated with this scene that can be re-created the next time the scene connects.
+    // The scene may re-connect later, as its session was not neccessarily discarded (see `application:didDiscardSceneSessions` instead).
+}
+
+
+- (void)sceneDidBecomeActive:(UIScene *)scene {
+    // Called when the scene has moved from an inactive state to an active state.
+    // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+}
+
+
+- (void)sceneWillResignActive:(UIScene *)scene {
+    // Called when the scene will move from an active state to an inactive state.
+    // This may occur due to temporary interruptions (ex. an incoming phone call).
+}
+
+
+- (void)sceneWillEnterForeground:(UIScene *)scene {
+    // Called as the scene transitions from the background to the foreground.
+    // Use this method to undo the changes made on entering the background.
+}
+
+
+- (void)sceneDidEnterBackground:(UIScene *)scene {
+    // Called as the scene transitions from the foreground to the background.
+    // Use this method to save data, release shared resources, and store enough scene-specific state information
+    // to restore the scene back to its current state.
+}
+
+
+@end

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/ViewController.h
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/ViewController.h
@@ -1,0 +1,17 @@
+//
+//  ViewController.h
+//  Toolbox-UI-Debugger
+//
+//  Created by Benjamin Reynolds on 4/3/20.
+//  Copyright © 2020 Reality Lab. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
+
+@interface ViewController : UIViewController<WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler>
+
+@property (nonatomic, strong) WKWebView* webView;
+
+@end
+

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/ViewController.m
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/ViewController.m
@@ -1,0 +1,117 @@
+//
+//  ViewController.m
+//  Toolbox-UI-Debugger
+//
+//  Created by Benjamin Reynolds on 4/3/20.
+//  Copyright © 2020 Reality Lab. All rights reserved.
+//
+
+#import "ViewController.h"
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+    
+    CGRect frame = CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height);
+    
+    // Create the configuration with the user content controller
+    WKUserContentController *userContentController = [WKUserContentController new];
+    [userContentController addScriptMessageHandler:self name:@"realityEditor"];
+    
+    WKWebViewConfiguration *configuration = [WKWebViewConfiguration new];
+    configuration.userContentController = userContentController;
+    configuration.allowsInlineMediaPlayback = YES;
+    configuration.requiresUserActionForMediaPlayback = NO;
+
+    self.webView = [[WKWebView alloc] initWithFrame:frame configuration:configuration];
+    
+//    [self.webView addObserver:self forKeyPath:@"loading" options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew context:nil];
+    
+    // set delegate
+    [self.webView setNavigationDelegate:self];
+    [self.webView setUIDelegate:self];
+    
+    // make it transparent
+    [self.webView setOpaque:NO];
+    [self.webView setBackgroundColor:[UIColor clearColor]];
+    [self.webView.window makeKeyAndVisible];
+    
+    // make it scrollable
+    [[self.webView scrollView] setScrollEnabled:NO];
+    [[self.webView scrollView] setBounces:NO];
+//    [REWebView allowDisplayingKeyboardWithoutUserAction];
+
+    // start the web server singleton as soon as possible to minimize loading times
+//    [self initializeWebServer];
+    
+    NSURL* url = [[NSBundle mainBundle] URLForResource:@"index" withExtension:@"html" subdirectory:@"userinterface"];
+    [self.webView loadRequest:[NSURLRequest requestWithURL:url]];
+    
+    [self.view addSubview:self.webView];
+}
+
+#pragma mark - JavaScript API Implementation
+
+- (void)handleCustomRequest:(NSDictionary *)messageBody {
+//    NSLog(@"Handle Request: %@", messageBody);
+    
+    NSString* functionName = messageBody[@"functionName"]; // required
+    NSDictionary* arguments = messageBody[@"arguments"]; // optional
+    NSString* callback = messageBody[@"callback"]; // optional
+
+    NSLog(@"Received custom request: %@", functionName);
+}
+
+#pragma mark - WKScriptMessageHandler Protocol Implementation
+
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
+{
+    [self handleCustomRequest: message.body];
+}
+
+#pragma mark - WKNavigaionDelegate Protocol Implementaion
+
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
+{
+    if (navigationAction.navigationType == WKNavigationTypeLinkActivated) {
+        if (navigationAction.request.URL) {
+            NSLog(@"%@", navigationAction.request.URL.host);
+            if ([navigationAction.request.URL.resourceSpecifier containsString:@"spatialtoolbox.vuforia.com"] ||
+                [navigationAction.request.URL.resourceSpecifier containsString:@"github.com"]) {
+                if ([[UIApplication sharedApplication] canOpenURL:navigationAction.request.URL]) {
+                    [[UIApplication sharedApplication] openURL:navigationAction.request.URL];
+                    decisionHandler(WKNavigationActionPolicyCancel);
+                }
+            } else {
+                decisionHandler(WKNavigationActionPolicyAllow);
+            }
+        }
+    } else {
+        decisionHandler(WKNavigationActionPolicyAllow);
+    }
+}
+
+#pragma mark - JavaScriptCallbackDelegate Protocol Implementation
+
+//- (void)callJavaScriptCallback:(NSString *)callback withArguments:(NSArray *)arguments
+//{
+////    if (!self.callbacksEnabled) return;
+//
+//    if (callback) {
+//        if (arguments && arguments.count > 0) {
+//            for (int i=0; i < arguments.count; i++) {
+//                callback = [callback stringByReplacingOccurrencesOfString:[NSString stringWithFormat:@"__ARG%i__", (i+1)] withString:arguments[i]];
+//            }
+//        }
+////        NSLog(@"Calling JavaScript callback: %@", callback);
+//        [self.webView runJavaScriptFromString:callback];
+//    }
+//}
+
+@end

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/main.m
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/main.m
@@ -1,0 +1,19 @@
+//
+//  main.m
+//  Toolbox-UI-Debugger
+//
+//  Created by Benjamin Reynolds on 4/3/20.
+//  Copyright © 2020 Reality Lab. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    NSString * appDelegateClassName;
+    @autoreleasepool {
+        // Setup code that might create autoreleased objects goes here.
+        appDelegateClassName = NSStringFromClass([AppDelegate class]);
+    }
+    return UIApplicationMain(argc, argv, nil, appDelegateClassName);
+}


### PR DESCRIPTION
Adds a second Xcode project to the repo in the subfolder "Toolbox-UI-Debugger"

This lets you run the app on a simulator, without Vuforia or any of the native iOS<>JS APIs, just to test the overall layout on different devices.

For example, I was able to identify a few layout problems with the intro screen on an iPad:

![Screen Shot 2020-04-03 at 4 17 48 PM](https://user-images.githubusercontent.com/32580292/78402435-9318b380-75c8-11ea-9e27-dc4c687c5dc0.png)