### PR TITLE
removed GCDWebServer lib Changed to new local Server URL

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,6 @@ target 'Vuforia Spatial Toolbox' do
 
   # Pods for Vuforia Spatial Toolbox
   pod 'CocoaAsyncSocket'
-  pod 'GCDWebServer', '~> 3.0'
   pod 'AFNetworking', '~> 3.0', :subspecs => ['NSURLSession']
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,26 +7,20 @@ PODS:
   - AFNetworking/Security (3.2.1)
   - AFNetworking/Serialization (3.2.1)
   - CocoaAsyncSocket (7.6.3)
-  - GCDWebServer (3.4.2):
-    - GCDWebServer/Core (= 3.4.2)
-  - GCDWebServer/Core (3.4.2)
 
 DEPENDENCIES:
   - AFNetworking/NSURLSession (~> 3.0)
   - CocoaAsyncSocket
-  - GCDWebServer (~> 3.0)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - AFNetworking
     - CocoaAsyncSocket
-    - GCDWebServer
 
 SPEC CHECKSUMS:
   AFNetworking: b6f891fdfaed196b46c7a83cf209e09697b94057
   CocoaAsyncSocket: eafaa68a7e0ec99ead0a7b35015e0bf25d2c8987
-  GCDWebServer: 8d67ee9f634b4bb91eb4b8aee440318a5fc6debd
 
-PODFILE CHECKSUM: 0f581365c9db2bc7e21a33d4d738b7a4379fed60
+PODFILE CHECKSUM: 4eb2b783265d1283b4d1aed1e2e10c18911a0c2a
 
 COCOAPODS: 1.5.3

--- a/Vuforia Spatial Toolbox.xcodeproj/project.pbxproj
+++ b/Vuforia Spatial Toolbox.xcodeproj/project.pbxproj
@@ -476,13 +476,11 @@
 				"${SRCROOT}/Pods/Target Support Files/Pods-Vuforia Spatial Toolbox/Pods-Vuforia Spatial Toolbox-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/AFNetworking/AFNetworking.framework",
 				"${BUILT_PRODUCTS_DIR}/CocoaAsyncSocket/CocoaAsyncSocket.framework",
-				"${BUILT_PRODUCTS_DIR}/GCDWebServer/GCDWebServer.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AFNetworking.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaAsyncSocket.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GCDWebServer.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Vuforia Spatial Toolbox/WebView/WebServerManager.h
+++ b/Vuforia Spatial Toolbox/WebView/WebServerManager.h
@@ -7,13 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class GCDWebServer;
-
-@interface WebServerManager : NSObject {
-    GCDWebServer* webServer;
-}
-
-@property (nonatomic, retain) GCDWebServer* webServer;
+@interface WebServerManager : NSObject
 
 - (NSURL *)getServerURL;
 

--- a/Vuforia Spatial Toolbox/WebView/WebServerManager.m
+++ b/Vuforia Spatial Toolbox/WebView/WebServerManager.m
@@ -4,15 +4,12 @@
 //
 //  Created by Benjamin Reynolds on 4/2/18.
 //
-// This is a singleton class that manages a GCDWebServer instance which is a local HTTP server
-// that hosts the Reality Editor userinterface (used to allows cross-origin access between iframes and source content)
+// This is a singleton class that manages a NodeRunner instance which runs a local instance of the Spatial Edge Server
 
 #import "WebServerManager.h"
 #import "NodeRunner.h"
 
 @implementation WebServerManager
-
-@synthesize webServer;
 
 #pragma mark - Singleton Methods
 
@@ -58,12 +55,7 @@
 }
 
 - (NSURL *)getServerURL {
-    //(webServer.serverURL)?webServer.serverURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://0.0.0.0:%d", webServer.port]];
-//    if ([webServer serverURL]) {
-   //     return [webServer "172.0"];
-//    } else {
      return [NSURL URLWithString:@"http://127.0.0.1:49368/"];
-//    }
 }
 
 @end

--- a/Vuforia Spatial Toolbox/WebView/WebServerManager.m
+++ b/Vuforia Spatial Toolbox/WebView/WebServerManager.m
@@ -8,7 +8,6 @@
 // that hosts the Reality Editor userinterface (used to allows cross-origin access between iframes and source content)
 
 #import "WebServerManager.h"
-#import "GCDWebServer.h"
 #import "NodeRunner.h"
 
 @implementation WebServerManager
@@ -63,7 +62,7 @@
 //    if ([webServer serverURL]) {
    //     return [webServer "172.0"];
 //    } else {
-     return [NSURL URLWithString:@"http://127.0.0.1:8888/"];
+     return [NSURL URLWithString:@"http://127.0.0.1:49368/"];
 //    }
 }
 


### PR DESCRIPTION
1. Removed references to GCDWebServer since we are not using that anymore
2. Changed server port to unregistered port range for preventing possible collision on mobile devices.
3. This change is possible due the changed in userinterface and server allowing flexible ports for server. 