### PR TITLE
fixes videorecording by adding port as parameter and using screenreco…

### DIFF
--- a/Vuforia Spatial Toolbox/JavaScriptAPIHandler.h
+++ b/Vuforia Spatial Toolbox/JavaScriptAPIHandler.h
@@ -50,7 +50,7 @@
 - (void)startSpeechRecording;
 - (void)stopSpeechRecording;
 - (void)addSpeechListener:(NSString *)callback;
-- (void)startVideoRecording:(NSString *)objectKey ip:(NSString *)objectIP;
+- (void)startVideoRecording:(NSString *)objectKey ip:(NSString *)objectIP port:(NSString *)objectPort;
 - (void)stopVideoRecording:(NSString *)videoId;
 - (void)tap;
 - (void)focusCamera;

--- a/Vuforia Spatial Toolbox/JavaScriptAPIHandler.mm
+++ b/Vuforia Spatial Toolbox/JavaScriptAPIHandler.mm
@@ -291,9 +291,9 @@
 }
 
 // objectKey is the ID of the object. objectIP is the IP of the server hosting this object.
-- (void)startVideoRecording:(NSString *)objectKey ip:(NSString *)objectIP
+- (void)startVideoRecording:(NSString *)objectKey ip:(NSString *)objectIP port:(NSString *)objectPort
 {
-    [[VideoRecordingManager sharedManager] startRecording:objectKey ip:objectIP];
+    [[VideoRecordingManager sharedManager] startRecording:objectKey ip:objectIP port:objectPort];
 }
 
 // videoID is a unique identifier for this video that will be used as its filename, so that the userinterface can load it from the server when ready.

--- a/Vuforia Spatial Toolbox/MainViewController.mm
+++ b/Vuforia Spatial Toolbox/MainViewController.mm
@@ -249,7 +249,8 @@
     } else if ([functionName isEqualToString:@"startVideoRecording"]) {
         NSString* objectKey = (NSString *)arguments[@"objectKey"];
         NSString* objectIP = (NSString *)arguments[@"objectIP"];
-        [self.apiHandler startVideoRecording:objectKey ip:objectIP];
+        NSString* objectPort = (NSString *)arguments[@"objectPort"];
+        [self.apiHandler startVideoRecording:objectKey ip:objectIP port:objectPort];
         
     } else if ([functionName isEqualToString:@"stopVideoRecording"]) {
         NSString* videoId = (NSString *)arguments[@"videoId"];

--- a/Vuforia Spatial Toolbox/VideoRecordingManager.h
+++ b/Vuforia Spatial Toolbox/VideoRecordingManager.h
@@ -25,10 +25,11 @@
 
 @property (strong, nonatomic) NSString* objectIP;
 @property (strong, nonatomic) NSString* objectID;
+@property (strong, nonatomic) NSString* objectPort;
 
 @property (nonatomic, assign) id<VideoRecordingDelegate> videoRecordingDelegate;
 
-- (void)startRecording:(NSString *)objectKey ip:(NSString *)objectIP;
+- (void)startRecording:(NSString *)objectKey ip:(NSString *)objectIP port:(NSString *)objectPort;
 - (void)stopRecording:(NSString *)videoId;
 
 @end

--- a/Vuforia Spatial Toolbox/VideoRecordingManager.m
+++ b/Vuforia Spatial Toolbox/VideoRecordingManager.m
@@ -39,7 +39,7 @@
 // This is a javascriptAPI-triggered function that starts recording the video feed from the camera background
 // The objectKey and IP are used to save the resulting video file at a certain location on a Reality Server
 // TODO: some optimization of startRecording and writeFrame should remove the slight lag while recording
-- (void)startRecordingWithoutAR:(NSString *)objectKey ip:(NSString *)objectIP port:(NSString *)objectPort
+- (void)startRecording:(NSString *)objectKey ip:(NSString *)objectIP port:(NSString *)objectPort
 {
     CGSize videoOutputSize = CGSizeMake(640, 360); // change this to compress the video to a smaller size. can go up to 1080p.
     float frameRate = 30; // change this to compress the video by recording more/less frames per second
@@ -52,7 +52,7 @@
     NSError *error = nil;
 
     // generates a random filename and saves to temp file directory before uploading to server
-    NSString *videoOutPath = [temporaryDirectory stringByAppendingPathComponent:[[NSString stringWithFormat:@"%u", arc4random() % 1000] stringByAppendingPathExtension:@"mp4"]];
+    NSString *videoOutPath = [temporaryDirectory stringByAppendingPathComponent:[[NSString stringWithFormat:@"%u", arc4random() % 10000] stringByAppendingPathExtension:@"mp4"]];
     
     // uses AVAssetWriter to write the camera stream to an mp4 file
     self.assetWriter = [AVAssetWriter assetWriterWithURL:[NSURL fileURLWithPath:videoOutPath] fileType:AVFileTypeMPEG4 error:&error];
@@ -158,7 +158,7 @@
 
 // This is a javascriptAPI-triggered function that stops the recording that is currently active
 // The resulting video file is uploaded to the Reality Server specified by the objectKey and IP provided when startVideoRecording was called
-- (void)stopRecordingWithoutAR:(NSString *)videoId
+- (void)stopRecording:(NSString *)videoId
 {
     if (!isRecording) {
         return;
@@ -191,14 +191,14 @@
 
 // Source: https://github.com/anthonya1999/ReplayKit-iOS11-Recorder/blob/master/ReplayKit-iOS11-Recorder/ViewController.m
 // TODO: fix startRecordingWithoutAR instead of using this
-- (void)startRecording:(NSString *)objectKey ip:(NSString *)objectIP port:(NSString *)objectPort
+- (void)startRecordingWithAR:(NSString *)objectKey ip:(NSString *)objectIP port:(NSString *)objectPort
 {
     CGSize videoOutputSize = CGSizeMake(640, 360); // change this to compress the video to a smaller size. can go up to 1080p.
 
     NSError *error = nil;
     
     // generates a random filename and saves to temp file directory before uploading to server
-    NSString *videoOutPath = [temporaryDirectory stringByAppendingPathComponent:[[NSString stringWithFormat:@"%u", arc4random() % 1000] stringByAppendingPathExtension:@"mp4"]];
+    NSString *videoOutPath = [temporaryDirectory stringByAppendingPathComponent:[[NSString stringWithFormat:@"%u", arc4random() % 10000] stringByAppendingPathExtension:@"mp4"]];
     self.assetWriter = [AVAssetWriter assetWriterWithURL:[NSURL fileURLWithPath:videoOutPath] fileType:AVFileTypeMPEG4 error:&error];
     
     NSDictionary *compressionProperties = @{AVVideoProfileLevelKey         : AVVideoProfileLevelH264BaselineAutoLevel,
@@ -255,7 +255,7 @@
 
 // Stops the recording started with startRecordingWithAR, and uploads the result to the server specified when startRecordingWithAR was called.
 // TODO: fix stopRecordingWithoutAR instead of using this
-- (void)stopRecording:(NSString *)videoId
+- (void)stopRecordingWithAR:(NSString *)videoId
 {
     [self.screenRecorder stopCaptureWithHandler:^(NSError * _Nullable error) {
         if (!error) {

--- a/Vuforia Spatial Toolbox/VideoRecordingManager.m
+++ b/Vuforia Spatial Toolbox/VideoRecordingManager.m
@@ -190,7 +190,6 @@
 // Use startRecording and stopRecording instead, which only record the camera background, not the AR elements.
 
 // Source: https://github.com/anthonya1999/ReplayKit-iOS11-Recorder/blob/master/ReplayKit-iOS11-Recorder/ViewController.m
-// TODO: fix startRecordingWithoutAR instead of using this
 - (void)startRecordingWithAR:(NSString *)objectKey ip:(NSString *)objectIP port:(NSString *)objectPort
 {
     CGSize videoOutputSize = CGSizeMake(640, 360); // change this to compress the video to a smaller size. can go up to 1080p.
@@ -254,7 +253,6 @@
 }
 
 // Stops the recording started with startRecordingWithAR, and uploads the result to the server specified when startRecordingWithAR was called.
-// TODO: fix stopRecordingWithoutAR instead of using this
 - (void)stopRecordingWithAR:(NSString *)videoId
 {
     [self.screenRecorder stopCaptureWithHandler:^(NSError * _Nullable error) {

--- a/Vuforia Spatial Toolbox/Vuforia Application/SampleAppRenderer.mm
+++ b/Vuforia Spatial Toolbox/Vuforia Application/SampleAppRenderer.mm
@@ -97,6 +97,19 @@
         NSLog(@"Could not initialise video background shader");
     }
     
+#pragma mark - Spatial Toolbox Extensions to Vuforia Sample Application (private properties)
+    self.videoRecordingShaderProgramID = [SampleApplicationShaderUtils createProgramWithVertexShaderFileName:@"BackgroundFlipped.vertsh"
+                                                                                      fragmentShaderFileName:@"Background.fragsh"];
+
+    if (0 < self.videoRecordingShaderProgramID) {
+        self.videoRecordingVertexHandle = glGetAttribLocation(self.videoRecordingShaderProgramID, "vertexPosition");
+        self.videoRecordingTexCoordHandle = glGetAttribLocation(self.videoRecordingShaderProgramID, "vertexTexCoord");
+        self.videoRecordingProjectionMatrixHandle = glGetUniformLocation(self.videoRecordingShaderProgramID, "projectionMatrix");
+        self.videoRecordingTexSampler2DHandle = glGetUniformLocation(self.videoRecordingShaderProgramID, "texSampler2D");
+    } else {
+        NSLog(@"Could not initialize video recording shader");
+    }
+#pragma mark -
 }
 
 
@@ -170,6 +183,13 @@
     
     glDisable(GL_SCISSOR_TEST);
     
+#pragma mark - Spatial Toolbox Extensions to Vuforia Sample Application
+    // reloads the pixel buffer containing the background every frame while the video is recording
+    if (isRecording) {
+        [self refreshBackgroundPixelBuffer];
+    }
+#pragma mark -
+
     mRenderer.end();
     
 }


### PR DESCRIPTION
…rding API instead of pixelbuffer (for now)

There were 3 independent problems making video recording not work anymore:

1) port 8080 was hardcoded into the upload URL, so videos placed on the local world object weren't hitting the endpoint anymore (since the local server is moved to port 49369
2) videos that try to save to local world object were failing to upload because the path required a successful mkdir which was failing
3) the custom pixel buffer screen recording method I wrote is somehow just recording a black screen now. I'm temporarily reverting to using the ReplayKit API to record the screen instead.

Solving all 3 also requires server PR: https://github.com/ptcrealitylab/vuforia-spatial-edge-server/pull/121
and userinterface PR: https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/pull/85