### PR TITLE
Fix bug that set all instant image targets to same size

### DIFF
--- a/Vuforia Spatial Toolbox/ARManager.mm
+++ b/Vuforia Spatial Toolbox/ARManager.mm
@@ -166,8 +166,6 @@
            
            // Get the runtime image source
            Vuforia::RuntimeImageSource* runtimeImageSource = objectTracker->getRuntimeImageSource();
-           
-           float targetWidthMeters = 1.0;
 
            // Load the data set from the given path.
            if (!runtimeImageSource->setFile([imagePath UTF8String], Vuforia::STORAGE_ABSOLUTE, targetWidthMeters, [objectID UTF8String]))


### PR DESCRIPTION
Removing a line that accidentally overwrote the custom size provided for instant image targets. Setting their size via the UI on the server web interface should work after this makes it into the published app version.

Fixes issue #33 