### PR TITLE
No changes to main app. Updates the Toolbox UI debugger Xcode project.

### DIFF
--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger.xcodeproj/project.pbxproj
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		43827DD92437CCD600994A7A /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43827DD82437CCD600994A7A /* WebKit.framework */; };
 		43827DDB2437CCDF00994A7A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43827DDA2437CCDF00994A7A /* UIKit.framework */; };
 		43827DDD2437CEDD00994A7A /* userinterface in Resources */ = {isa = PBXBuildFile; fileRef = 43827DDC2437CEDD00994A7A /* userinterface */; };
+		43EE015924B8D781005659F0 /* REWebViewSimplified.mm in Sources */ = {isa = PBXBuildFile; fileRef = 43EE015824B8D781005659F0 /* REWebViewSimplified.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -35,6 +36,8 @@
 		43827DD82437CCD600994A7A /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		43827DDA2437CCDF00994A7A /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		43827DDC2437CEDD00994A7A /* userinterface */ = {isa = PBXFileReference; lastKnownFileType = folder; name = userinterface; path = ../../bin/data/userinterface; sourceTree = "<group>"; };
+		43EE015724B8D781005659F0 /* REWebViewSimplified.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = REWebViewSimplified.h; sourceTree = "<group>"; };
+		43EE015824B8D781005659F0 /* REWebViewSimplified.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = REWebViewSimplified.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,6 +80,8 @@
 				43827DC22437CCB500994A7A /* SceneDelegate.m */,
 				43827DC42437CCB500994A7A /* ViewController.h */,
 				43827DC52437CCB500994A7A /* ViewController.m */,
+				43EE015724B8D781005659F0 /* REWebViewSimplified.h */,
+				43EE015824B8D781005659F0 /* REWebViewSimplified.mm */,
 				43827DC72437CCB500994A7A /* Main.storyboard */,
 				43827DCA2437CCB500994A7A /* Assets.xcassets */,
 				43827DCC2437CCB500994A7A /* LaunchScreen.storyboard */,
@@ -166,6 +171,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43EE015924B8D781005659F0 /* REWebViewSimplified.mm in Sources */,
 				43827DC62437CCB500994A7A /* ViewController.m in Sources */,
 				43827DC02437CCB500994A7A /* AppDelegate.m in Sources */,
 				43827DD12437CCB500994A7A /* main.m in Sources */,

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/REWebViewSimplified.h
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/REWebViewSimplified.h
@@ -1,0 +1,19 @@
+//
+//  REWebView.h
+//  Vuforia Spatial Toolbox
+//
+//  Created by Benjamin Reynolds on 7/2/18.
+//  Copyright © 2018 PTC. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
+
+@interface REWebViewSimplified : WKWebView
+
+- (id)initWithDelegate:(id<WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler>)delegate;
+- (void)loadInterfaceFromURL:(NSString *)urlString;
+- (void)runJavaScriptFromString:(NSString *)script;
+- (void)clearCache;
+
+@end

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/REWebViewSimplified.h
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/REWebViewSimplified.h
@@ -1,10 +1,12 @@
 //
-//  REWebView.h
+//  REWebViewSimplified.h
 //  Vuforia Spatial Toolbox
 //
 //  Created by Benjamin Reynolds on 7/2/18.
 //  Copyright © 2018 PTC. All rights reserved.
 //
+// This is a modified version of REWebView.h, which removes all references to the Node.js server
+// as that server is unnecessary for debugging layout of the app UI
 
 #import <UIKit/UIKit.h>
 #import <WebKit/WebKit.h>

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/REWebViewSimplified.mm
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/REWebViewSimplified.mm
@@ -1,0 +1,151 @@
+//
+//  REWebView.m
+//  Vuforia Spatial Toolbox
+//
+//  Created by Benjamin Reynolds on 7/2/18.
+//  Copyright © 2018 PTC. All rights reserved.
+//
+// This is a customized WKWebView that initializes with correct configurations for the Reality Editor userinterface,
+// loads its interface from a self-hosted local HTTP server, and knows how to handle JS <-> Objective-C messages
+
+#import "REWebViewSimplified.h"
+#import <objc/runtime.h>
+
+@implementation REWebViewSimplified
+
+// creates a customized web view for the Reality Editor with fullscreen size, clear background, no scroll,
+// and sets a delegate to handle script messages sent to the iOS code from JavaScript
+- (id)initWithDelegate:(id<WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler>)delegate
+{
+    // automatically make it fullscreen
+    CGRect frame = CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height);
+    
+    // initialize the UIWebView instance
+
+//    CGFloat xOffset = 0;
+//#ifdef IS_IOS11orHIGHER
+//    UILayoutGuide* layoutGuide = [[UIApplication sharedApplication] keyWindow].safeAreaLayoutGuide;
+//    xOffset = layoutGuide.layoutFrame.origin.x;
+//#endif
+//
+//    frame = CGRectMake(-1 * xOffset, 0, xOffset + [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height);
+
+    // Create the configuration with the user content controller
+    WKUserContentController *userContentController = [WKUserContentController new];
+    [userContentController addScriptMessageHandler:delegate name:@"realityEditor"];
+    
+    WKWebViewConfiguration *configuration = [WKWebViewConfiguration new];
+    configuration.userContentController = userContentController;
+    configuration.allowsInlineMediaPlayback = YES;
+    configuration.requiresUserActionForMediaPlayback = NO;
+    
+    if (self = [super initWithFrame:frame configuration:configuration]) {
+
+        // set delegate
+        [self setNavigationDelegate:delegate];
+        [self setUIDelegate:delegate];
+        
+        // make it transparent
+        [self setOpaque:NO];
+        [self setBackgroundColor:[UIColor clearColor]];
+        [self.window makeKeyAndVisible];
+        
+        // make it scrollable
+        [[self scrollView] setScrollEnabled:NO];
+        [[self scrollView] setBounces:NO];
+        [REWebViewSimplified allowDisplayingKeyboardWithoutUserAction];
+        
+        NSLog(@"Initialized REWebViewSimplified");
+    }
+    return self;
+}
+
+// Allows javascript to programmatically open the keyboard without explicitly tapping on a native text field element (disabled by default)
+// Non-intuitive solution, taken from https://stackoverflow.com/a/48623286/1190267 (updated for iOS 12 and 13 as of 3-4-2020)
++ (void)allowDisplayingKeyboardWithoutUserAction {
+    Class thisClass = NSClassFromString(@"WKContentView");
+    NSOperatingSystemVersion iOS_11_3_0 = (NSOperatingSystemVersion){11, 3, 0};
+    NSOperatingSystemVersion iOS_12_2_0 = (NSOperatingSystemVersion){12, 2, 0};
+    NSOperatingSystemVersion iOS_13_0_0 = (NSOperatingSystemVersion){13, 0, 0};
+    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion: iOS_13_0_0]) {
+        SEL selector = sel_getUid("_elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:");
+        Method method = class_getInstanceMethod(thisClass, selector);
+        IMP original = method_getImplementation(method);
+        IMP override = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, BOOL arg3, id arg4) {
+        ((void (*)(id, SEL, void*, BOOL, BOOL, BOOL, id))original)(me, selector, arg0, TRUE, arg2, arg3, arg4);
+        });
+        method_setImplementation(method, override);
+    }
+   else if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion: iOS_12_2_0]) {
+        SEL selector = sel_getUid("_elementDidFocus:userIsInteracting:blurPreviousNode:changingActivityState:userObject:");
+        Method method = class_getInstanceMethod(thisClass, selector);
+        IMP original = method_getImplementation(method);
+        IMP override = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, BOOL arg3, id arg4) {
+        ((void (*)(id, SEL, void*, BOOL, BOOL, BOOL, id))original)(me, selector, arg0, TRUE, arg2, arg3, arg4);
+        });
+        method_setImplementation(method, override);
+    }
+    else if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion: iOS_11_3_0]) {
+        SEL selector = sel_getUid("_startAssistingNode:userIsInteracting:blurPreviousNode:changingActivityState:userObject:");
+        Method method = class_getInstanceMethod(thisClass, selector);
+        IMP original = method_getImplementation(method);
+        IMP override = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, BOOL arg3, id arg4) {
+            ((void (*)(id, SEL, void*, BOOL, BOOL, BOOL, id))original)(me, selector, arg0, TRUE, arg2, arg3, arg4);
+        });
+        method_setImplementation(method, override);
+    } else {
+        SEL selector = sel_getUid("_startAssistingNode:userIsInteracting:blurPreviousNode:userObject:");
+        Method method = class_getInstanceMethod(thisClass, selector);
+        IMP original = method_getImplementation(method);
+        IMP override = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, id arg3) {
+            ((void (*)(id, SEL, void*, BOOL, BOOL, id))original)(me, selector, arg0, TRUE, arg2, arg3);
+        });
+        method_setImplementation(method, override);
+    }
+}
+
+// override the safe area inserts for iPhoneX fullscreen
+// https://stackoverflow.com/questions/47244002/make-wkwebview-real-fullscreen-on-iphone-x-remove-safe-area-from-wkwebview
+// https://stackoverflow.com/questions/51547468/override-safeareainsets-for-wkwebview-in-objective-c?noredirect=1&lq=1
+- (UIEdgeInsets)safeAreaInsets {
+    return UIEdgeInsetsMake(0.0f, 0.0f, 0.0f, 0.0f);
+}
+
+- (void)loadInterfaceFromURL:(NSString *)urlString
+{
+    if (urlString.length == 0) {
+        return;
+    }
+    if (![urlString containsString:@"http://"]) {
+        urlString = [NSString stringWithFormat:@"http://%@", urlString];
+    }
+    urlString = [urlString stringByReplacingOccurrencesOfString:@"\"" withString:@""]; // remove any quotes from the string that may have been added during storage encoding
+    
+    [[NSURLCache sharedURLCache] removeAllCachedResponses];
+    [self clearCache];
+//    [self loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:urlString]]];
+    [self loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:urlString] cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:10.0f]];
+}
+
+// calls the javascript string on the window (global context) of the webview contents
+- (void)runJavaScriptFromString:(NSString *)script
+{
+    // strip out newlines to prevent Unexpected EOF error
+    script = [script stringByReplacingOccurrencesOfString:@"\n" withString:@""];
+    script = [script stringByReplacingOccurrencesOfString:@"\r" withString:@""];
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self evaluateJavaScript:script completionHandler:nil];
+    });
+}
+
+// this can be used to force the webview to reload the source files in case they don't update when developing
+- (void)clearCache
+{
+    NSSet *dataTypes = [NSSet setWithArray:@[WKWebsiteDataTypeDiskCache,WKWebsiteDataTypeMemoryCache,]];
+    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:dataTypes
+                                               modifiedSince:[NSDate dateWithTimeIntervalSince1970:0]
+                                           completionHandler:^{}];
+}
+
+@end

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/REWebViewSimplified.mm
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/REWebViewSimplified.mm
@@ -1,12 +1,15 @@
 //
-//  REWebView.m
+//  REWebViewSimplified.mm
 //  Vuforia Spatial Toolbox
 //
 //  Created by Benjamin Reynolds on 7/2/18.
 //  Copyright © 2018 PTC. All rights reserved.
 //
 // This is a customized WKWebView that initializes with correct configurations for the Reality Editor userinterface,
-// loads its interface from a self-hosted local HTTP server, and knows how to handle JS <-> Objective-C messages
+//  and knows how to handle JS <-> Objective-C messages
+//
+// This is a modified version of REWebView.m, which removes all references to the Node.js server
+// as that server is unnecessary for debugging layout of the app UI
 
 #import "REWebViewSimplified.h"
 #import <objc/runtime.h>
@@ -17,18 +20,7 @@
 // and sets a delegate to handle script messages sent to the iOS code from JavaScript
 - (id)initWithDelegate:(id<WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler>)delegate
 {
-    // automatically make it fullscreen
-    CGRect frame = CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height);
-    
-    // initialize the UIWebView instance
-
-//    CGFloat xOffset = 0;
-//#ifdef IS_IOS11orHIGHER
-//    UILayoutGuide* layoutGuide = [[UIApplication sharedApplication] keyWindow].safeAreaLayoutGuide;
-//    xOffset = layoutGuide.layoutFrame.origin.x;
-//#endif
-//
-//    frame = CGRectMake(-1 * xOffset, 0, xOffset + [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height);
+    // initialize the WKWebView instance
 
     // Create the configuration with the user content controller
     WKUserContentController *userContentController = [WKUserContentController new];
@@ -39,6 +31,9 @@
     configuration.allowsInlineMediaPlayback = YES;
     configuration.requiresUserActionForMediaPlayback = NO;
     
+    // make it fullscreen
+    CGRect frame = CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height);
+
     if (self = [super initWithFrame:frame configuration:configuration]) {
 
         // set delegate
@@ -123,7 +118,6 @@
     
     [[NSURLCache sharedURLCache] removeAllCachedResponses];
     [self clearCache];
-//    [self loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:urlString]]];
     [self loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:urlString] cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:10.0f]];
 }
 

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/ViewController.h
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/ViewController.h
@@ -9,9 +9,11 @@
 #import <UIKit/UIKit.h>
 #import <WebKit/WebKit.h>
 
+@class REWebViewSimplified;
+
 @interface ViewController : UIViewController<WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler>
 
-@property (nonatomic, strong) WKWebView* webView;
+@property (nonatomic, strong) REWebViewSimplified* webView;
 
 @end
 

--- a/Toolbox-UI-Debugger/Toolbox-UI-Debugger/ViewController.m
+++ b/Toolbox-UI-Debugger/Toolbox-UI-Debugger/ViewController.m
@@ -6,12 +6,8 @@
 //  Copyright © 2020 Reality Lab. All rights reserved.
 //
 
-// Instructions: When you change the simulator, change this string to match the targeted device
-#define DEVICE_NAME @"iPhone11,2"
-
 #import "ViewController.h"
 #import "REWebViewSimplified.h"
-#import <sys/utsname.h>
 
 @interface ViewController ()
 
@@ -43,16 +39,8 @@
     NSLog(@"Received custom request: %@", functionName);
     
     if ([functionName isEqualToString:@"getDeviceReady"]) {
-        
-        // This method doesn't work on the simulator so we manually use the DEVICE_NAME constant instead
-        /*
-        struct utsname systemInfo;
-        uname(&systemInfo);
-        NSString* deviceName = [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
-        */
-        
-        NSString* deviceName = DEVICE_NAME;
-        
+        // This works on the simulator only, make sure not to copy this implementation of getDeviceReady into the AR app
+        NSString* deviceName = [NSString stringWithCString:getenv("SIMULATOR_MODEL_IDENTIFIER") encoding:NSUTF8StringEncoding];
         [self callJavaScriptCallback:callback withArguments:@[[NSString stringWithFormat:@"'%@'", deviceName]]];
     }
 }

--- a/Vuforia Spatial Toolbox.xcodeproj/xcshareddata/xcschemes/Release.xcscheme
+++ b/Vuforia Spatial Toolbox.xcodeproj/xcshareddata/xcschemes/Release.xcscheme
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "43D0350820EAC02600AA1039"
+               BuildableName = "Vuforia Spatial Toolbox.app"
+               BlueprintName = "Vuforia Spatial Toolbox"
+               ReferencedContainer = "container:Vuforia Spatial Toolbox.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "43D0350820EAC02600AA1039"
+            BuildableName = "Vuforia Spatial Toolbox.app"
+            BlueprintName = "Vuforia Spatial Toolbox"
+            ReferencedContainer = "container:Vuforia Spatial Toolbox.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "43D0350820EAC02600AA1039"
+            BuildableName = "Vuforia Spatial Toolbox.app"
+            BlueprintName = "Vuforia Spatial Toolbox"
+            ReferencedContainer = "container:Vuforia Spatial Toolbox.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Updates the simulator-friendly project to use the REWebView so that layout happens correctly. currently uses a constant that needs to be manually updated in ViewController.m to set the DEVICE_NAME to match the simulator used.

Beforehand I was using a vanilla WKWebView to contain the userinterface. But in the real app, it uses a customized web view called the REWebView. In this PR, I copy-and-pasted that code and slightly modified it to create a REWebViewSimplified class to host the userinterface. This recreates the environment that is used in the app, so that the layout is correct in the simulator. I also added a listener for the getDeviceReady API that sends the simulator device name to the javascript code for layout purposes.