### PR TITLE
Optimize groundplane tracker

### DIFF
--- a/Vuforia Spatial Toolbox.xcodeproj/project.pbxproj
+++ b/Vuforia Spatial Toolbox.xcodeproj/project.pbxproj
@@ -737,6 +737,10 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
+				"FRAMEWORK_SEARCH_PATHS[arch=*]" = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+				);
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_OPTIMIZATION_LEVEL = s;
 				INFOPLIST_FILE = "Vuforia Spatial Toolbox/Info.plist";

--- a/Vuforia Spatial Toolbox.xcodeproj/project.pbxproj
+++ b/Vuforia Spatial Toolbox.xcodeproj/project.pbxproj
@@ -737,10 +737,6 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
-				"FRAMEWORK_SEARCH_PATHS[arch=*]" = (
-					"$(inherited)",
-					"$(PROJECT_DIR)",
-				);
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_OPTIMIZATION_LEVEL = s;
 				INFOPLIST_FILE = "Vuforia Spatial Toolbox/Info.plist";

--- a/Vuforia Spatial Toolbox/ARManager.h
+++ b/Vuforia Spatial Toolbox/ARManager.h
@@ -63,4 +63,6 @@ typedef void (^ MatrixStringCompletionHandler)(NSString *);
 - (void)focusCamera;
 - (bool)tryPlacingGroundAnchorAtScreenX:(float)normalizedScreenX andScreenY:(float)normalizedScreenY;
 
+- (bool)startGroundPlaneTracker;
+
 @end

--- a/Vuforia Spatial Toolbox/ARManager.h
+++ b/Vuforia Spatial Toolbox/ARManager.h
@@ -64,5 +64,6 @@ typedef void (^ MatrixStringCompletionHandler)(NSString *);
 - (bool)tryPlacingGroundAnchorAtScreenX:(float)normalizedScreenX andScreenY:(float)normalizedScreenY;
 
 - (bool)startGroundPlaneTracker;
+- (bool)stopGroundPlaneTracker;
 
 @end

--- a/Vuforia Spatial Toolbox/ARManager.mm
+++ b/Vuforia Spatial Toolbox/ARManager.mm
@@ -418,7 +418,6 @@
     return isAnchorResultAvailable;
 }
 
-// also stops the groundplane tracking if it successfully places an anchor
 - (BOOL) performHitTestWithNormalizedTouchPointX:(float)normalizedTouchPointX
                         andNormalizedTouchPointY:(float)normalizedTouchPointY
                         withDeviceHeightInMeters:(float) deviceHeightInMeters
@@ -465,8 +464,6 @@
             if (mHitTestAnchor != nullptr)
             {
                 NSLog(@"Successfully created hit test anchor with name '%s'", mHitTestAnchor->getName());
-//                [self stopGroundPlaneTracker];
-                NSLog(@"Stopped groundplane because we found the ground!");
             }
             else
             {
@@ -608,8 +605,6 @@
         NSLog(@"Successfully started DeviceTracker");
     }
     
-    // [self startGroundPlaneTracker]; // don't start groundplane until something needs it (via getGroundPlaneMatrixStream)
-
     // Start area target tracker
     if (!disableAreaTargetTracker) {
         NSLog(@"TODO: start area target tracker");
@@ -621,6 +616,8 @@
         }
         NSLog(@"Successfully started Area Tracker");
     }
+
+    // unlike other trackers, don't start groundplane until something needs it (via getGroundPlaneMatrixStream)
 
     return true;
 }
@@ -644,10 +641,7 @@
         }
         deviceTracker->stop();
     }
-    
-    [self stopGroundPlaneTracker];
-    
-    // Start area target tracker
+        
     if (!disableAreaTargetTracker) {
         Vuforia::AreaTracker* areaTracker = static_cast<Vuforia::AreaTracker*>(trackerManager.getTracker(Vuforia::AreaTracker::getClassType()));
         if (areaTracker == 0) {
@@ -656,6 +650,8 @@
         }
         areaTracker->stop();
     }
+    
+    [self stopGroundPlaneTracker];
     
     NSLog(@"doStopTrackers");
     return true;

--- a/Vuforia Spatial Toolbox/ARManager.mm
+++ b/Vuforia Spatial Toolbox/ARManager.mm
@@ -465,7 +465,7 @@
             if (mHitTestAnchor != nullptr)
             {
                 NSLog(@"Successfully created hit test anchor with name '%s'", mHitTestAnchor->getName());
-                [self stopGroundPlaneTracker];
+//                [self stopGroundPlaneTracker];
                 NSLog(@"Stopped groundplane because we found the ground!");
             }
             else
@@ -666,6 +666,17 @@
     // Start ground plane tracker
     if (!disableGroundPlaneTracker) {
         Vuforia::TrackerManager& trackerManager = Vuforia::TrackerManager::getInstance();
+
+        Vuforia::PositionalDeviceTracker* deviceTracker = static_cast<Vuforia::PositionalDeviceTracker*> (trackerManager.getTracker(Vuforia::PositionalDeviceTracker::getClassType()));
+        // Destroy previous hit test anchor if needed
+        if (deviceTracker != nullptr && mHitTestAnchor != nullptr)
+        {
+            NSLog(@"Destroying hit test anchor with name '%s'", HIT_TEST_ANCHOR_NAME);
+            bool result = deviceTracker->destroyAnchor(mHitTestAnchor);
+            NSLog(@"%s hit test anchor", (result ? "Successfully destroyed" : "Failed to destroy"));
+            mHitTestAnchor = nullptr;
+        }
+        
         Vuforia::Tracker* smartTerrain = trackerManager.getTracker(Vuforia::SmartTerrain::getClassType());
         if (smartTerrain == nullptr || !smartTerrain->start())
         {

--- a/Vuforia Spatial Toolbox/JavaScriptAPIHandler.h
+++ b/Vuforia Spatial Toolbox/JavaScriptAPIHandler.h
@@ -35,6 +35,7 @@
 - (void)getMatrixStream:(NSString *)callback;
 - (void)getCameraMatrixStream:(NSString *)callback;
 - (void)getGroundPlaneMatrixStream:(NSString *)callback;
+- (void)acceptGroundPlaneAndStop;
 - (void)getScreenshot:(NSString *)size callback:(NSString *)callback;
 - (void)setPause;
 - (void)setResume;

--- a/Vuforia Spatial Toolbox/JavaScriptAPIHandler.mm
+++ b/Vuforia Spatial Toolbox/JavaScriptAPIHandler.mm
@@ -139,6 +139,8 @@
 {
     __block JavaScriptAPIHandler *blocksafeSelf = self; // https://stackoverflow.com/a/5023583/1190267
 
+    [[ARManager sharedManager] startGroundPlaneTracker]; // start the ground plane tracker if it isn't already set
+    
     [[ARManager sharedManager] setGroundPlaneMatrixCompletionHandler:^(NSDictionary *groundPlaneMarker) {
         NSString* groundPlaneMatrix = groundPlaneMarker[@"modelViewMatrix"];
         [blocksafeSelf->delegate callJavaScriptCallback:callback withArguments:@[groundPlaneMatrix]];

--- a/Vuforia Spatial Toolbox/JavaScriptAPIHandler.mm
+++ b/Vuforia Spatial Toolbox/JavaScriptAPIHandler.mm
@@ -139,7 +139,8 @@
 {
     __block JavaScriptAPIHandler *blocksafeSelf = self; // https://stackoverflow.com/a/5023583/1190267
 
-    [[ARManager sharedManager] startGroundPlaneTracker]; // start the ground plane tracker if it isn't already set
+    // start the smartTerrain tracker (and reset groundplane origin anchor if already set)
+    [[ARManager sharedManager] startGroundPlaneTracker];
     
     [[ARManager sharedManager] setGroundPlaneMatrixCompletionHandler:^(NSDictionary *groundPlaneMarker) {
         NSString* groundPlaneMatrix = groundPlaneMarker[@"modelViewMatrix"];

--- a/Vuforia Spatial Toolbox/JavaScriptAPIHandler.mm
+++ b/Vuforia Spatial Toolbox/JavaScriptAPIHandler.mm
@@ -147,6 +147,11 @@
     }];
 }
 
+- (void)acceptGroundPlaneAndStop
+{
+    [[ARManager sharedManager] stopGroundPlaneTracker];
+}
+
 // TODO: actually use size when getting screenshot
 - (void)getScreenshot:(NSString *)size callback:(NSString *)callback
 {

--- a/Vuforia Spatial Toolbox/MainViewController.mm
+++ b/Vuforia Spatial Toolbox/MainViewController.mm
@@ -192,6 +192,9 @@
     } else if ([functionName isEqualToString:@"getGroundPlaneMatrixStream"]) {
         [self.apiHandler getGroundPlaneMatrixStream:callback];
 
+    } else if ([functionName isEqualToString:@"acceptGroundPlaneAndStop"]) {
+        [self.apiHandler acceptGroundPlaneAndStop];
+
     } else if ([functionName isEqualToString:@"getScreenshot"]) {
         NSString* size = (NSString *)arguments[@"size"];
         [self.apiHandler getScreenshot:size callback:callback];


### PR DESCRIPTION
Updates for iOS project to not unnecessarily search for ground plane once it's already been set (adds `acceptGroundPlaneAndStop` API that the JS userinterface can call) and to allow the ground plane to be recalculated on demand (whenever `getGroundPlaneMatrixStream` is called again in the userinterface – e.g. when the reset button is pressed – causes the ground plane origin anchor to be destroyed and recalculated)