### PR TITLE
App lifecycle events & support for tracking status

### DIFF
--- a/Vuforia Spatial Toolbox/ARManager.mm
+++ b/Vuforia Spatial Toolbox/ARManager.mm
@@ -701,7 +701,6 @@
     return true;
 }
 
-
 - (BOOL) doUnloadTrackersData
 {
     Vuforia::TrackerManager& trackerManager = Vuforia::TrackerManager::getInstance();
@@ -736,9 +735,22 @@
 - (bool) doDeinitTrackers
 {
     Vuforia::TrackerManager& trackerManager = Vuforia::TrackerManager::getInstance();
+
+    // object tracker
     trackerManager.deinitTracker(Vuforia::ObjectTracker::getClassType());
+
+    // additional enabled trackers
+
     if (!disablePositionalDeviceTracker) {
         trackerManager.deinitTracker(Vuforia::PositionalDeviceTracker::getClassType());
+    }
+
+    if (!disableGroundPlaneTracker) {
+        trackerManager.deinitTracker(Vuforia::SmartTerrain::getClassType());
+    }
+
+    if (!disableAreaTargetTracker) {
+        trackerManager.deinitTracker(Vuforia::AreaTracker::getClassType());
     }
     
     NSLog(@"doDeinitTrackers");
@@ -788,6 +800,7 @@
 
             if(result->getStatus() != Vuforia::TrackableResult::DETECTED &&
                result->getStatus() != Vuforia::TrackableResult::TRACKED &&
+               result->getStatus() != Vuforia::TrackableResult::LIMITED &&
                result->getStatus() != Vuforia::TrackableResult::EXTENDED_TRACKED) {
                 continue;
             }
@@ -829,6 +842,9 @@
             // send in Positional Device Trackers' information in a different way, via the camera matrix
             if (!disablePositionalDeviceTracker) {
                 if (trackable.isOfType(Vuforia::DeviceTrackable::getClassType())) {
+                    // if (result->getStatus() == Vuforia::TrackableResult::LIMITED) {
+                    //     NSLog(@"Limited tracking (%u)", result->getStatusInfo()); // TODO: send reason for limited tracking status to userinterface
+                    // }
                     deviceTrackableResult = result;
                     if (cameraMatrixCompletionHandler) {
                         cameraMatrixCompletionHandler(marker);

--- a/Vuforia Spatial Toolbox/ARManager.mm
+++ b/Vuforia Spatial Toolbox/ARManager.mm
@@ -877,9 +877,6 @@
             // send in Positional Device Trackers' information in a different way, via the camera matrix
             if (!disablePositionalDeviceTracker) {
                 if (trackable.isOfType(Vuforia::DeviceTrackable::getClassType())) {
-//                     if (result->getStatus() == Vuforia::TrackableResult::LIMITED) {
-//                         NSLog(@"Limited tracking (%u)", result->getStatusInfo());
-//                     }
                     deviceTrackableResult = result;
                     if (cameraMatrixCompletionHandler) {
                         cameraMatrixCompletionHandler(marker);
@@ -925,46 +922,11 @@
 - (void)restartDeviceTracker
 {
     Vuforia::TrackerManager& trackerManager = Vuforia::TrackerManager::getInstance();
-
-    /*
-    [self pauseAR];
     
-    Vuforia::TrackerManager& trackerManager = Vuforia::TrackerManager::getInstance();
-
-    if (!disablePositionalDeviceTracker) {
-        
-//        Vuforia::Tracker* deviceTracker = trackerManager.getTracker(Vuforia::PositionalDeviceTracker::getClassType());
-//        if (deviceTracker == 0) {
-//            NSLog(@"Error stopping device tracker");
-//            return;
-//        }
-//        deviceTracker->stop();
-        
-        if (!trackerManager.deinitTracker(Vuforia::PositionalDeviceTracker::getClassType())) {
-            NSLog(@"Failed to de-initialize DeviceTracker in reinit method");
-            return;
-        }
-        
-        Vuforia::Tracker* newDeviceTracker = trackerManager.initTracker(Vuforia::PositionalDeviceTracker::getClassType());
-        if (newDeviceTracker == nullptr)
-        {
-            NSLog(@"Failed to initialize DeviceTracker in reinit method");
-            return;
-        }
-        
-//        if (!newDeviceTracker->start())
-//        {
-//            NSLog(@"Failed to start DeviceTracker");
-//            return;
-//        }
-//        NSLog(@"Successfully started DeviceTracker");
-    }
-    
-    [self resumeAR];
-     */
-
-//    Vuforia::Tracker* deviceTracker = trackerManager.getTracker(Vuforia::PositionalDeviceTracker::getClassType());
     Vuforia::PositionalDeviceTracker* deviceTracker = static_cast<Vuforia::PositionalDeviceTracker*> (trackerManager.getTracker(Vuforia::PositionalDeviceTracker::getClassType()));
+    
+    // reset() clears all anchors from the positional device tracker, effectively moving its (0,0,0) to the current position
+    // this fixes issues if the tracker was stuck in LIMITED:ROLOCALIZING status
     deviceTracker->reset();
     
     NSLog(@"Successfully re-initialized DeviceTracker");

--- a/Vuforia Spatial Toolbox/DeviceStateManager.h
+++ b/Vuforia Spatial Toolbox/DeviceStateManager.h
@@ -21,6 +21,7 @@ typedef void (^ CompletionHandlerWithString)(NSString *);
 
 + (id)sharedManager;
 - (void)enableOrientationChanges:(CompletionHandlerWithString)completionHandler;
+- (void)subscribeToAppLifeCycleEvents:(CompletionHandlerWithString)completionHandler;
 
 @property (nonatomic, strong) UIView* viewToRotate;
 

--- a/Vuforia Spatial Toolbox/DeviceStateManager.m
+++ b/Vuforia Spatial Toolbox/DeviceStateManager.m
@@ -39,7 +39,7 @@
        name:UIDeviceOrientationDidChangeNotification
        object:[UIDevice currentDevice]];
 
-    __block DeviceStateManager *blocksafeSelf = self; // https://stackoverflow.com/a/5023583/1190267
+    __block DeviceStateManager *blocksafeSelf = self;
 
     // trigger the callback once with the current orientation
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{

--- a/Vuforia Spatial Toolbox/JavaScriptAPIHandler.h
+++ b/Vuforia Spatial Toolbox/JavaScriptAPIHandler.h
@@ -61,5 +61,6 @@
 - (void)clearCache;
 // TODO: add authenticateTouch(?)
 - (void)enableOrientationChanges:(NSString *)callback;
+- (void)subscribeToAppLifeCycleEvents:(NSString *)callback;
 
 @end

--- a/Vuforia Spatial Toolbox/JavaScriptAPIHandler.h
+++ b/Vuforia Spatial Toolbox/JavaScriptAPIHandler.h
@@ -62,5 +62,6 @@
 // TODO: add authenticateTouch(?)
 - (void)enableOrientationChanges:(NSString *)callback;
 - (void)subscribeToAppLifeCycleEvents:(NSString *)callback;
+- (void)restartDeviceTracker;
 
 @end

--- a/Vuforia Spatial Toolbox/JavaScriptAPIHandler.mm
+++ b/Vuforia Spatial Toolbox/JavaScriptAPIHandler.mm
@@ -355,4 +355,14 @@
     }];
 }
 
+// triggers callbacks to notify the UI when the app is moved to background or resumed
+- (void)subscribeToAppLifeCycleEvents:(NSString *)callback
+{
+    __block JavaScriptAPIHandler *blocksafeSelf = self; // https://stackoverflow.com/a/5023583/1190267
+
+    [[DeviceStateManager sharedManager] subscribeToAppLifeCycleEvents:^(NSString *eventName) {
+        [blocksafeSelf->delegate callJavaScriptCallback:callback withArguments:@[[NSString stringWithFormat:@"'%@'", eventName]]];
+    }];
+}
+
 @end

--- a/Vuforia Spatial Toolbox/JavaScriptAPIHandler.mm
+++ b/Vuforia Spatial Toolbox/JavaScriptAPIHandler.mm
@@ -129,12 +129,12 @@
 {
     __block JavaScriptAPIHandler *blocksafeSelf = self; // https://stackoverflow.com/a/5023583/1190267
     
-    // old method just sends matrix
-//    [[ARManager sharedManager] setCameraMatrixCompletionHandler:^(NSDictionary *cameraMarker) {
-//        NSString* cameraMatrix = cameraMarker[@"modelViewMatrix"];
-//        [blocksafeSelf->delegate callJavaScriptCallback:callback withArguments:@[cameraMatrix]];
-//    }];
-
+    // old method just sent matrix
+    // [[ARManager sharedManager] setCameraMatrixCompletionHandler:^(NSDictionary *cameraMarker) {
+    //     NSString* cameraMatrix = cameraMarker[@"modelViewMatrix"];
+    //     [blocksafeSelf->delegate callJavaScriptCallback:callback withArguments:@[cameraMatrix]];
+    // }];
+    
     // new method also sends tracking status and tracking status info
     
     [[ARManager sharedManager] setCameraMatrixCompletionHandler:^(NSDictionary *cameraMarker) {
@@ -143,14 +143,8 @@
         NSString* trackingStatus = cameraMarker[@"trackingStatus"];
         NSString* trackingStatusInfo = cameraMarker[@"trackingStatusInfo"];
         
-//        NSDictionary* marker = @{@"name": [NSString stringWithUTF8String:trackable.getName()],
-//                                 @"modelViewMatrix": [self stringFromMatrix44F:modelViewMatrixCorrected],
-//                                 @"trackingStatus": trackingStatus,
-//                                 @"trackingStatusInfo": trackingStatusInfo
-//        }
-        
         NSString* javascriptObject = [NSString stringWithFormat:@"{ 'matrix': %@, 'status': '%@', 'statusInfo': '%@' }", cameraMatrix, trackingStatus, trackingStatusInfo];
-                                 
+        
         [blocksafeSelf->delegate callJavaScriptCallback:callback withArguments:@[javascriptObject]];
         
     }];

--- a/Vuforia Spatial Toolbox/JavaScriptAPIHandler.mm
+++ b/Vuforia Spatial Toolbox/JavaScriptAPIHandler.mm
@@ -129,9 +129,30 @@
 {
     __block JavaScriptAPIHandler *blocksafeSelf = self; // https://stackoverflow.com/a/5023583/1190267
     
+    // old method just sends matrix
+//    [[ARManager sharedManager] setCameraMatrixCompletionHandler:^(NSDictionary *cameraMarker) {
+//        NSString* cameraMatrix = cameraMarker[@"modelViewMatrix"];
+//        [blocksafeSelf->delegate callJavaScriptCallback:callback withArguments:@[cameraMatrix]];
+//    }];
+
+    // new method also sends tracking status and tracking status info
+    
     [[ARManager sharedManager] setCameraMatrixCompletionHandler:^(NSDictionary *cameraMarker) {
+        
         NSString* cameraMatrix = cameraMarker[@"modelViewMatrix"];
-        [blocksafeSelf->delegate callJavaScriptCallback:callback withArguments:@[cameraMatrix]];
+        NSString* trackingStatus = cameraMarker[@"trackingStatus"];
+        NSString* trackingStatusInfo = cameraMarker[@"trackingStatusInfo"];
+        
+//        NSDictionary* marker = @{@"name": [NSString stringWithUTF8String:trackable.getName()],
+//                                 @"modelViewMatrix": [self stringFromMatrix44F:modelViewMatrixCorrected],
+//                                 @"trackingStatus": trackingStatus,
+//                                 @"trackingStatusInfo": trackingStatusInfo
+//        }
+        
+        NSString* javascriptObject = [NSString stringWithFormat:@"{ 'matrix': %@, 'status': '%@', 'statusInfo': '%@' }", cameraMatrix, trackingStatus, trackingStatusInfo];
+                                 
+        [blocksafeSelf->delegate callJavaScriptCallback:callback withArguments:@[javascriptObject]];
+        
     }];
 }
 
@@ -363,6 +384,11 @@
     [[DeviceStateManager sharedManager] subscribeToAppLifeCycleEvents:^(NSString *eventName) {
         [blocksafeSelf->delegate callJavaScriptCallback:callback withArguments:@[[NSString stringWithFormat:@"'%@'", eventName]]];
     }];
+}
+
+- (void)restartDeviceTracker
+{
+    [[ARManager sharedManager] restartDeviceTracker];
 }
 
 @end

--- a/Vuforia Spatial Toolbox/MainViewController.mm
+++ b/Vuforia Spatial Toolbox/MainViewController.mm
@@ -278,6 +278,9 @@
 
     } else if ([functionName isEqualToString:@"enableOrientationChanges"]) {
         [self.apiHandler enableOrientationChanges:callback]; // the callback triggers whenever device orientation changes
+    
+    } else if ([functionName isEqualToString:@"subscribeToAppLifeCycleEvents"]) {
+        [self.apiHandler subscribeToAppLifeCycleEvents:callback];
     }
 }
 

--- a/Vuforia Spatial Toolbox/MainViewController.mm
+++ b/Vuforia Spatial Toolbox/MainViewController.mm
@@ -281,6 +281,9 @@
     
     } else if ([functionName isEqualToString:@"subscribeToAppLifeCycleEvents"]) {
         [self.apiHandler subscribeToAppLifeCycleEvents:callback];
+    
+    } else if ([functionName isEqualToString:@"restartDeviceTracker"]) {
+        [self.apiHandler restartDeviceTracker];
     }
 }
 

--- a/Vuforia Spatial Toolbox/WebView/REWebView.mm
+++ b/Vuforia Spatial Toolbox/WebView/REWebView.mm
@@ -49,7 +49,9 @@
         [self setOpaque:NO];
         [self setBackgroundColor:[UIColor clearColor]];
         [self.window makeKeyAndVisible];
-        
+        [self setAllowsLinkPreview:NO];
+        [self setAllowsBackForwardNavigationGestures:NO];
+
         // make it scrollable
         [[self scrollView] setScrollEnabled:NO];
         [[self scrollView] setBounces:NO];


### PR DESCRIPTION
- Adds APIs for the userinterface to subscribe to the app's lifecycle (moving to background, becoming active again)
- Keeps track of the trackingStatus of the positional device tracker and if LIMITED, notes the reason
- Sends camera position matrices to userinterface in new format which includes this tracking status (**note** this requires updating the userinterface to https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/pull/145 and vice versa - PR is not compatible with older userinterface versions)