### PR TITLE
Fix pixel buffer size to allow screen recording on larger iOS devices (iPhone 11 plus, etc)

### DIFF
--- a/Vuforia Spatial Toolbox/Vuforia Application/SampleAppRenderer.mm
+++ b/Vuforia Spatial Toolbox/Vuforia Application/SampleAppRenderer.mm
@@ -37,7 +37,8 @@
     #pragma mark - Spatial Toolbox Extensions to Vuforia Sample Application (private fields)
     BOOL isRecording;
     CGSize maxScreenSize; // if the screen is bigger than this, we clip it when writing to video
-    GLchar pixels[(1920) * (1080) * 4 + 1]; // allocates at least enough memory for the video, since we don't know the exact screen resolution until runtime. sized to fit the 1080p video. ensure maxScreenSize is set to the same dimensions. the +1 shifts the buffer from RGBA to ARGB. bad side effect is that alpha channel is shifted by 1 pixel, but because the alph channel is uniform it doesn't matter
+    // IMPORTANT: this needs to be manually set so that it fits the largest available screen size of any iOS device (currently iPhone 11 Pro is 2688x1242)
+    GLchar pixels[(2688) * (1242) * 4 + 1]; // allocates at least enough memory for the video, since we don't know the exact screen resolution until runtime. sized to fit the 1080p video. ensure maxScreenSize is set to the same dimensions. the +1 shifts the buffer from RGBA to ARGB. bad side effect is that alpha channel is shifted by 1 pixel, but because the alph channel is uniform it doesn't matter
     #pragma mark -
 }
 // SampleApplicationControl delegate (receives callbacks in response to particular

--- a/Vuforia Spatial Toolbox/Vuforia Application/SampleAppRenderer.mm
+++ b/Vuforia Spatial Toolbox/Vuforia Application/SampleAppRenderer.mm
@@ -36,9 +36,7 @@
 {
     #pragma mark - Spatial Toolbox Extensions to Vuforia Sample Application (private fields)
     BOOL isRecording;
-    CGSize maxScreenSize; // if the screen is bigger than this, we clip it when writing to video
-    // IMPORTANT: this needs to be manually set so that it fits the largest available screen size of any iOS device (currently iPhone 11 Pro is 2688x1242)
-    GLchar pixels[(2688) * (1242) * 4 + 1]; // allocates at least enough memory for the video, since we don't know the exact screen resolution until runtime. sized to fit the 1080p video. ensure maxScreenSize is set to the same dimensions. the +1 shifts the buffer from RGBA to ARGB. bad side effect is that alpha channel is shifted by 1 pixel, but because the alph channel is uniform it doesn't matter
+    GLchar* pixels;
     #pragma mark -
 }
 // SampleApplicationControl delegate (receives callbacks in response to particular
@@ -79,6 +77,11 @@
     if (self) {
         self.control = control;
         [self setNearPlane:nearPlane farPlane:farPlane];
+
+        // allocate memory for the video. the +1 shifts the buffer from RGBA to ARGB.
+        // (the only bad side effect is that alpha channel is shifted by 1 pixel, but because the alph channel is uniform it doesn't matter)
+        CGSize screenSize = [self getCurrentARViewBoundsSize];
+        pixels = new GLchar[(screenSize.width) * (screenSize.height) * 4 + 1];
     }
     return self;
 }


### PR DESCRIPTION
Anyone know a more future-proof fix for this? Just need to create a pixel buffer with at least the size of the screen (but seems I can't access that info at compile time). In the meantime, this fixes the issue until they create a new iPhone with more pixels.